### PR TITLE
Implement feature extraction for vision models

### DIFF
--- a/pot/vision/models.py
+++ b/pot/vision/models.py
@@ -13,10 +13,44 @@ class VisionModel:
         self.model_name = model_name
         self.device = device
         self.model = None
-        
+
     def get_features(self, x: torch.Tensor) -> torch.Tensor:
-        """Extract features from input image"""
-        raise NotImplementedError("Subclasses must implement get_features")
+        """Extract features from the penultimate layer of the model.
+
+        For ResNet architectures the activations are taken after the global
+        average pooling layer (before the final classifier). If no model is
+        loaded or the model name is ``mock`` a deterministic projection of the
+        input tensor is returned. All feature vectors are L2 normalised and
+        moved to the configured device.
+        """
+
+        # Move inputs to the configured device
+        x = x.to(self.device)
+
+        # Handle mock models or cases where no underlying model is provided
+        if self.model is None or self.model_name == "mock":
+            # Use a simple deterministic projection based on the input
+            batch_size = x.shape[0] if x.dim() > 1 else 1
+            flat = x.view(batch_size, -1)
+            feature_dim = getattr(self, "feature_dim", flat.shape[1])
+            pooled = nn.functional.adaptive_avg_pool1d(
+                flat.unsqueeze(1), feature_dim
+            ).squeeze(1)
+            return nn.functional.normalize(pooled, p=2, dim=1)
+
+        # Ensure model is on the correct device and in eval mode
+        self.model = self.model.to(self.device)
+        self.model.eval()
+
+        # Extract all layers except the final classifier
+        modules = list(self.model.children())
+        feature_extractor = nn.Sequential(*modules[:-1]) if len(modules) > 1 else self.model
+
+        with torch.no_grad():
+            feats = feature_extractor(x)
+            feats = torch.flatten(feats, 1)
+            feats = nn.functional.normalize(feats, p=2, dim=1)
+        return feats
     
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Forward pass through model"""
@@ -30,11 +64,10 @@ class MockVisionModel(VisionModel):
     def __init__(self, feature_dim: int = 512):
         super().__init__(model_name="mock", device="cpu")
         self.feature_dim = feature_dim
-        
+
     def get_features(self, x: torch.Tensor) -> torch.Tensor:
-        """Return random features for testing"""
-        batch_size = x.shape[0] if x.dim() > 3 else 1
-        return torch.randn(batch_size, self.feature_dim)
+        """Deterministic feature extraction for testing."""
+        return super().get_features(x)
 
 def load_resnet(variant: str, num_classes: int, seed: int = 0) -> nn.Module:
     torch.manual_seed(seed)

--- a/pot/vision/test_models.py
+++ b/pot/vision/test_models.py
@@ -1,0 +1,35 @@
+import torch
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from pot.vision import models
+
+
+def test_mock_model_features_deterministic_shape():
+    model = models.MockVisionModel(feature_dim=16)
+    x = torch.randn(2, 3, 8, 8)
+    f1 = model.get_features(x)
+    f2 = model.get_features(x)
+    assert f1.shape == (2, 16)
+    assert torch.allclose(f1, f2)
+    norms = f1.norm(dim=1)
+    assert torch.allclose(norms, torch.ones_like(norms))
+    assert f1.device.type == model.device
+
+
+@pytest.mark.parametrize("variant, dim", [("resnet18", 512), ("resnet50", 2048)])
+def test_resnet_features_deterministic_shape(variant, dim):
+    if not models.TORCHVISION_AVAILABLE:
+        pytest.skip("torchvision not available")
+    vm = models.VisionModel(model_name=variant)
+    vm.model = models.load_resnet(variant, num_classes=10)
+    x = torch.randn(2, 3, 32, 32)
+    f1 = vm.get_features(x)
+    f2 = vm.get_features(x)
+    assert f1.shape == (2, dim)
+    assert torch.allclose(f1, f2)
+    norms = f1.norm(dim=1)
+    assert torch.allclose(norms, torch.ones_like(norms))
+    assert f1.device.type == vm.device


### PR DESCRIPTION
## Summary
- Extract penultimate layer activations for vision models with normalization
- Support mock models and ResNet18/50 in `get_features`
- Add deterministic shape tests for feature extraction

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fc4d6c208832d92090a05125c7117
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Implemented penultimate-layer feature extraction with L2-normalized outputs for vision models. Supports mock models and ResNet18/50, with tests for shape, determinism, normalization, and device handling.

- **New Features**
  - ResNet: take activations after global average pooling, flatten, L2-normalize, run in no_grad, and move to the configured device.
  - Mock: replace random outputs with a deterministic adaptive pooling projection to feature_dim, then L2-normalize.
  - Add tests for mock and ResNet18/50 covering output shape, determinism, unit norms, and device.

<!-- End of auto-generated description by cubic. -->

