### PR TITLE
Add statistical fingerprinting baseline with tests

### DIFF
--- a/pot/eval/baselines.py
+++ b/pot/eval/baselines.py
@@ -1,10 +1,29 @@
+import hashlib
+import json
+import numpy as np
+
 # Baseline verification methods
+
+
 def naive_io_hash(outputs):
     """Naive I/O hash baseline"""
-    import hashlib
     return hashlib.sha256(str(outputs).encode()).hexdigest()
 
-def lightweight_fingerprint(model, challenges):
-    """Lightweight fingerprinting placeholder"""
-    # TODO: implement basic fingerprinting
-    pass
+
+def statistical_fingerprint(outputs, quantiles=(0.25, 0.5, 0.75)):
+    """Compute a statistical fingerprint of the given outputs."""
+    arr = np.asarray(outputs, dtype=np.float64).ravel()
+    stats = {
+        "mean": float(np.mean(arr)),
+        "std": float(np.std(arr)),
+        "quantiles": [float(q) for q in np.quantile(arr, quantiles)],
+    }
+    serialized = json.dumps(stats, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(serialized).hexdigest()
+
+
+def lightweight_fingerprint(model, challenges, quantiles=(0.25, 0.5, 0.75)):
+    """Generate a statistical fingerprint for model outputs."""
+    outputs = [model(c) for c in challenges]
+    return statistical_fingerprint(outputs, quantiles=quantiles)
+

--- a/pot/eval/test_baselines.py
+++ b/pot/eval/test_baselines.py
@@ -1,0 +1,20 @@
+import os
+import sys
+import numpy as np
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+from pot.eval.baselines import statistical_fingerprint
+
+
+def test_statistical_fingerprint_identical():
+    outputs1 = np.array([0.1, 0.2, 0.3])
+    outputs2 = np.array([0.1, 0.2, 0.3])
+    assert statistical_fingerprint(outputs1) == statistical_fingerprint(outputs2)
+
+
+def test_statistical_fingerprint_perturbed():
+    outputs = np.array([0.1, 0.2, 0.3])
+    perturbed = outputs.copy()
+    perturbed[0] += 0.01
+    assert statistical_fingerprint(outputs) != statistical_fingerprint(perturbed)
+


### PR DESCRIPTION
## Summary
- implement statistical_fingerprint computing mean, std, and quantiles and hashing them
- use statistical_fingerprint in lightweight_fingerprint
- add tests checking fingerprints match for identical outputs and diverge when perturbed

## Testing
- `pytest pot/eval/test_baselines.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689fc4d83db0832d85c39e0c47a86bf6
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a statistical fingerprint baseline that hashes mean, std, and quantiles of model outputs, and uses it in lightweight_fingerprint. Includes tests to verify identical outputs match and small perturbations produce different fingerprints.

<!-- End of auto-generated description by cubic. -->

