### PR TITLE
Add probit-scale DET plot with save option and tests

### DIFF
--- a/pot/eval/plots.py
+++ b/pot/eval/plots.py
@@ -1,39 +1,74 @@
 import matplotlib.pyplot as plt
 import seaborn as sns
 import numpy as np
-from typing import Dict, List
+from typing import Dict, List, Optional
+from scipy.stats import norm
+
 
 def plot_roc_curve(far_values: List[float], frr_values: List[float], title: str = "ROC Curve"):
     """Plot ROC curve"""
     plt.figure(figsize=(8, 6))
-    plt.plot(far_values, 1 - np.array(frr_values), 'b-', linewidth=2)
-    plt.xlabel('False Accept Rate')
-    plt.ylabel('True Accept Rate')
+    plt.plot(far_values, 1 - np.array(frr_values), "b-", linewidth=2)
+    plt.xlabel("False Accept Rate")
+    plt.ylabel("True Accept Rate")
     plt.title(title)
     plt.grid(True, alpha=0.3)
     plt.show()
 
-def plot_det_curve(far_values: List[float], frr_values: List[float], title: str = "DET Curve"):
-    """Plot Detection Error Tradeoff curve"""
-    # TODO: implement DET curve with probit scale
-    pass
+
+def plot_det_curve(
+    far_values: List[float],
+    frr_values: List[float],
+    title: str = "DET Curve",
+    save_path: Optional[str] = None,
+):
+    """Plot Detection Error Tradeoff curve on a probit scale.
+
+    Args:
+        far_values: False accept rates as probabilities.
+        frr_values: False reject rates as probabilities.
+        title: Title for the plot.
+        save_path: Optional path to save the generated figure.
+
+    Returns:
+        The matplotlib figure containing the DET curve.
+    """
+
+    # Convert to numpy arrays and clip to avoid infinities in the probit transform
+    far = np.clip(np.asarray(far_values), 1e-10, 1 - 1e-10)
+    frr = np.clip(np.asarray(frr_values), 1e-10, 1 - 1e-10)
+
+    fig, ax = plt.subplots(figsize=(8, 6))
+    ax.plot(norm.ppf(far), norm.ppf(frr), "b-", linewidth=2)
+    ax.set_xlabel("False Accept Rate (FAR)")
+    ax.set_ylabel("False Reject Rate (FRR)")
+    ax.set_title(title)
+    ax.grid(True, alpha=0.3)
+
+    if save_path is not None:
+        fig.savefig(save_path)
+
+    return fig
+
 
 def plot_auroc_vs_queries(query_budgets: List[int], auroc_values: List[float]):
     """Plot AUROC vs query budget"""
     plt.figure(figsize=(8, 6))
-    plt.plot(query_budgets, auroc_values, 'o-', linewidth=2)
-    plt.xlabel('Query Budget')
-    plt.ylabel('AUROC')
-    plt.title('AUROC vs Query Budget')
+    plt.plot(query_budgets, auroc_values, "o-", linewidth=2)
+    plt.xlabel("Query Budget")
+    plt.ylabel("AUROC")
+    plt.title("AUROC vs Query Budget")
     plt.grid(True, alpha=0.3)
     plt.show()
+
 
 def plot_leakage_curve(rho_values: List[float], detection_rates: List[float]):
     """Plot detection rate vs leakage fraction"""
     plt.figure(figsize=(8, 6))
-    plt.plot(rho_values, detection_rates, 'r^-', linewidth=2)
-    plt.xlabel('Leakage Fraction (ρ)')
-    plt.ylabel('Detection Rate')
-    plt.title('Detection vs Leakage')
+    plt.plot(rho_values, detection_rates, "r^-", linewidth=2)
+    plt.xlabel("Leakage Fraction (ρ)")
+    plt.ylabel("Detection Rate")
+    plt.title("Detection vs Leakage")
     plt.grid(True, alpha=0.3)
     plt.show()
+

--- a/pot/eval/test_plots.py
+++ b/pot/eval/test_plots.py
@@ -1,0 +1,21 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+from pot.eval.plots import plot_det_curve
+
+
+def test_plot_det_curve_labels_and_save(tmp_path):
+    far = np.linspace(0.01, 0.99, 10)
+    frr = 1 - far
+    save_file = tmp_path / "det_curve.png"
+
+    fig = plot_det_curve(far, frr, title="Test DET", save_path=str(save_file))
+
+    assert isinstance(fig, plt.Figure)
+    ax = fig.axes[0]
+    assert ax.get_xlabel() == "False Accept Rate (FAR)"
+    assert ax.get_ylabel() == "False Reject Rate (FRR)"
+    assert save_file.exists()
+
+    plt.close(fig)
+


### PR DESCRIPTION
## Summary
- implement Detection Error Tradeoff plotting on a probit scale using `scipy.stats.norm.ppf`
- allow optionally saving the figure to disk and return the matplotlib figure
- add tests covering axis labels and file saving

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fc4d96920832dbc757a86d52e8e93
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a probit-scale DET plot with an option to save the figure and return the Matplotlib Figure. Added tests to verify axis labels and file saving.

- **New Features**
  - Plot DET on a probit scale using scipy.stats.norm.ppf; clip rates to avoid infinities.
  - New save_path parameter to write the figure to disk; function returns the Figure.
  - Standardized axis labels: "False Accept Rate (FAR)" and "False Reject Rate (FRR)".
  - Tests cover labels, return type, and file creation.

<!-- End of auto-generated description by cubic. -->

