### PR TITLE
Implement attack algorithms and expose hyperparameters

### DIFF
--- a/pot/core/attacks.py
+++ b/pot/core/attacks.py
@@ -1,62 +1,220 @@
-"""Shared attack implementations for both vision and language models."""
+"""Shared attack implementations for both vision and language models.
 
-import numpy as np
-from typing import Any, Dict, Optional
+This module implements lightweight versions of common attack strategies used in
+the literature.  The goal is not to be optimised or feature complete, but to
+provide functioning reference implementations that can be used in tests and
+examples.  All attacks operate on generic :class:`torch.nn.Module` objects so
+that they can be applied to either vision or language models.
+"""
+
+from typing import Any, Callable, Dict, Optional
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+import torch.nn.functional as F
 
 
-def targeted_finetune(model: Any, target_outputs: np.ndarray, epochs: int = 10) -> Any:
-    """Targeted fine-tuning attack on model.
-    
+def targeted_finetune(
+    model: nn.Module,
+    data_loader: DataLoader,
+    epochs: int = 10,
+    lr: float = 1e-3,
+    loss_fn: Optional[Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = None,
+) -> nn.Module:
+    """Targeted fine‑tuning attack.
+
+    This attack follows the approach of Carlini et al. (2020) where a model is
+    fine‑tuned on a small set of leaked challenge/response pairs in order to
+    steer its behaviour toward attacker chosen outputs.
+
     Args:
-        model: Model to attack
-        target_outputs: Target outputs to fine-tune towards
-        epochs: Number of fine-tuning epochs
-        
+        model: Model to attack.
+        data_loader: Iterable of ``(inputs, target_outputs)`` pairs.
+        epochs: Number of fine‑tuning epochs.
+        lr: Optimiser learning rate.
+        loss_fn: Optional loss function. Defaults to ``nn.MSELoss``.
+
     Returns:
-        Fine-tuned model
+        Fine‑tuned model (modified in place).
     """
-    # Placeholder for actual fine-tuning logic
+
+    model.train()
+    optimiser = torch.optim.Adam(model.parameters(), lr=lr)
+    criterion = loss_fn or nn.MSELoss()
+
+    for _ in range(epochs):
+        for x, y in data_loader:
+            optimiser.zero_grad()
+            pred = model(x)
+            loss = criterion(pred, y)
+            loss.backward()
+            optimiser.step()
+
     return model
 
 
-def limited_distillation(teacher_model: Any, budget: int = 1000, temperature: float = 4.0) -> Any:
-    """Limited distillation attack.
-    
+def limited_distillation(
+    teacher_model: nn.Module,
+    student_model: nn.Module,
+    data_loader: DataLoader,
+    budget: int = 1000,
+    temperature: float = 4.0,
+    epochs: int = 1,
+    lr: float = 1e-3,
+) -> nn.Module:
+    """Limited knowledge distillation attack.
+
+    Inspired by Papernot et al. (2016), the attacker queries the victim model
+    (teacher) to train a student model using at most ``budget`` examples.  The
+    distillation temperature controls the softness of the teacher's
+    distribution.
+
     Args:
-        teacher_model: Model to distill from
-        budget: Query budget for distillation
-        temperature: Distillation temperature
-        
+        teacher_model: Victim model providing soft targets.
+        student_model: Model to train.
+        data_loader: Iterable providing query inputs.
+        budget: Maximum number of queries allowed.
+        temperature: Distillation temperature.
+        epochs: Number of training epochs over the queried data.
+        lr: Optimiser learning rate.
+
     Returns:
-        Distilled student model
+        Trained student model.
     """
-    # Placeholder for actual distillation logic
-    return teacher_model
+
+    teacher_model.eval()
+    student_model.train()
+
+    optimiser = torch.optim.Adam(student_model.parameters(), lr=lr)
+    criterion = nn.KLDivLoss(reduction="batchmean")
+
+    queries = 0
+    collected_x: list[torch.Tensor] = []
+    collected_y: list[torch.Tensor] = []
+
+    # Gather up to ``budget`` query/response pairs from the teacher model.
+    for x, _ in data_loader:
+        if queries >= budget:
+            break
+        batch = x[: max(0, min(x.size(0), budget - queries))]
+        with torch.no_grad():
+            logits = teacher_model(batch) / temperature
+            probs = F.softmax(logits, dim=-1)
+        collected_x.append(batch)
+        collected_y.append(probs)
+        queries += batch.size(0)
+
+    if not collected_x:
+        return student_model
+
+    dataset = TensorDataset(torch.cat(collected_x), torch.cat(collected_y))
+    loader = DataLoader(dataset, batch_size=32, shuffle=True)
+
+    for _ in range(epochs):
+        for x_batch, y_batch in loader:
+            optimiser.zero_grad()
+            student_logits = student_model(x_batch) / temperature
+            log_probs = F.log_softmax(student_logits, dim=-1)
+            loss = criterion(log_probs, y_batch)
+            loss.backward()
+            optimiser.step()
+
+    return student_model
 
 
-def wrapper_attack(model: Any, routing_logic: Optional[Dict] = None) -> Any:
-    """Wrapper attack that routes queries.
-    
+def wrapper_attack(
+    model: nn.Module,
+    routing_logic: Optional[Dict[Callable[[torch.Tensor], bool], nn.Module]] = None,
+) -> nn.Module:
+    """Wrapper attack that routes queries based on predicates.
+
+    The attack wraps a base model and consults a user supplied ``routing_logic``
+    mapping.  When a predicate evaluates to ``True`` for a given input, the
+    corresponding model is used to generate the response instead of the base
+    model.  This mirrors the wrapper attacks described by Wallace et al. (2021).
+
     Args:
-        model: Model to wrap
-        routing_logic: Optional routing configuration
-        
+        model: Base model to wrap.
+        routing_logic: Mapping from predicate callables to replacement models.
+
     Returns:
-        Wrapped model with routing
+        A new model that applies the routing logic before delegating to the
+        underlying model.
     """
-    # Placeholder for wrapper attack
-    return model
+
+    class Wrapper(nn.Module):
+        def __init__(self, base: nn.Module, logic: Optional[Dict]):
+            super().__init__()
+            self.base = base
+            self.logic = logic or {}
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            for predicate, alt_model in self.logic.items():
+                if predicate(x):
+                    return alt_model(x)
+            return self.base(x)
+
+    return Wrapper(model, routing_logic)
 
 
-def extraction_attack(model: Any, query_budget: int = 10000) -> Any:
-    """Model extraction attack.
-    
+def extraction_attack(
+    model: nn.Module,
+    data_loader: DataLoader,
+    query_budget: int = 10000,
+    epochs: int = 1,
+    lr: float = 1e-3,
+) -> nn.Module:
+    """Model extraction via query synthesis.
+
+    Implements the strategy of Tramèr et al. (2016) where an attacker trains a
+    surrogate model using outputs queried from the victim.  A simple linear
+    surrogate is fit using mean squared error.
+
     Args:
-        model: Model to extract
-        query_budget: Number of queries allowed
-        
+        model: Victim model to emulate.
+        data_loader: Source of query inputs.
+        query_budget: Maximum number of queries to the victim model.
+        epochs: Training epochs for the surrogate.
+        lr: Optimiser learning rate.
+
     Returns:
-        Extracted model approximation
+        Extracted surrogate model.
     """
-    # Placeholder for extraction attack
-    return model
+
+    model.eval()
+    queries = 0
+    xs: list[torch.Tensor] = []
+    ys: list[torch.Tensor] = []
+
+    for x, _ in data_loader:
+        if queries >= query_budget:
+            break
+        batch = x[: max(0, min(x.size(0), query_budget - queries))]
+        with torch.no_grad():
+            y = model(batch)
+        xs.append(batch)
+        ys.append(y)
+        queries += batch.size(0)
+
+    if not xs:
+        raise ValueError("No queries collected for extraction attack")
+
+    X = torch.cat(xs)
+    Y = torch.cat(ys)
+    input_dim = X.shape[1]
+    output_dim = Y.shape[1]
+    surrogate = nn.Linear(input_dim, output_dim)
+    optimiser = torch.optim.Adam(surrogate.parameters(), lr=lr)
+    dataset = TensorDataset(X, Y)
+    loader = DataLoader(dataset, batch_size=32, shuffle=True)
+
+    for _ in range(epochs):
+        for x_batch, y_batch in loader:
+            optimiser.zero_grad()
+            pred = surrogate(x_batch)
+            loss = F.mse_loss(pred, y_batch)
+            loss.backward()
+            optimiser.step()
+
+    return surrogate

--- a/tests/test_attacks_integration.py
+++ b/tests/test_attacks_integration.py
@@ -1,0 +1,104 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+
+from pot.core.attacks import (
+    extraction_attack,
+    limited_distillation,
+    targeted_finetune,
+    wrapper_attack,
+)
+from pot.core.fingerprint import io_hash
+
+
+def test_targeted_finetune_changes_model_and_hash():
+    torch.manual_seed(0)
+    model = nn.Linear(1, 1)
+    inputs = torch.linspace(-1, 1, 20).unsqueeze(1)
+    targets = 2 * inputs
+    loader = DataLoader(TensorDataset(inputs, targets), batch_size=5, shuffle=True)
+
+    before_weight = model.weight.clone()
+    baseline_hash = io_hash(model(inputs).detach().numpy())
+
+    targeted_finetune(model, loader, epochs=20, lr=0.1)
+
+    after_hash = io_hash(model(inputs).detach().numpy())
+
+    assert not torch.allclose(before_weight, model.weight)
+    assert baseline_hash != after_hash
+
+
+def test_limited_distillation_reduces_teacher_student_gap():
+    torch.manual_seed(0)
+    teacher = nn.Linear(1, 1)
+    with torch.no_grad():
+        teacher.weight.fill_(2.0)
+        teacher.bias.zero_()
+
+    student = nn.Linear(1, 1)
+
+    data_x = torch.linspace(-1, 1, 100).unsqueeze(1)
+    loader = DataLoader(TensorDataset(data_x, torch.zeros_like(data_x)), batch_size=10, shuffle=True)
+
+    baseline_mse = torch.mean((student(data_x) - teacher(data_x)) ** 2).item()
+
+    limited_distillation(
+        teacher,
+        student,
+        loader,
+        budget=50,
+        temperature=2.0,
+        epochs=5,
+        lr=0.05,
+    )
+
+    post_mse = torch.mean((student(data_x) - teacher(data_x)) ** 2).item()
+    assert post_mse < baseline_mse
+
+
+def test_wrapper_attack_routes_inputs():
+    class ConstantModel(nn.Module):
+        def __init__(self, value: float):
+            super().__init__()
+            self.value = value
+
+        def forward(self, x):
+            return torch.full((x.size(0), 1), self.value)
+
+    base = nn.Linear(1, 1)
+    const_model = ConstantModel(42.0)
+
+    def predicate(x):
+        return (x > 0).any().item()
+
+    wrapped = wrapper_attack(base, {predicate: const_model})
+
+    inputs = torch.tensor([[-1.0], [1.0]])
+    base_out = base(inputs)
+    wrapped_out = wrapped(inputs)
+
+    assert not torch.allclose(base_out, wrapped_out)
+    assert io_hash(base_out.detach().numpy()) != io_hash(wrapped_out.detach().numpy())
+
+
+def test_extraction_attack_trains_surrogate():
+    torch.manual_seed(0)
+    victim = nn.Linear(1, 1)
+    with torch.no_grad():
+        victim.weight.fill_(3.0)
+        victim.bias.fill_(-2.0)
+
+    x = torch.linspace(-1, 1, 200).unsqueeze(1)
+    loader = DataLoader(TensorDataset(x, torch.zeros_like(x)), batch_size=20, shuffle=True)
+
+    test_x = torch.linspace(-1, 1, 50).unsqueeze(1)
+    baseline = nn.Linear(1, 1)
+    baseline_mse = torch.mean((baseline(test_x) - victim(test_x)) ** 2).item()
+
+    surrogate = extraction_attack(victim, loader, query_budget=100, epochs=5, lr=0.05)
+    surrogate_mse = torch.mean((surrogate(test_x) - victim(test_x)) ** 2).item()
+
+    assert surrogate_mse < baseline_mse


### PR DESCRIPTION
## Summary
- Implement real attack algorithms: targeted fine-tuning, limited distillation, wrapper routing, and model extraction
- Expose epochs, temperature, routing, and query budget hyperparameters in run_attack script
- Add integration tests for attack effects (skipped if PyTorch unavailable)

## Testing
- `pytest pot/security -q`
- `pytest tests/test_attacks_integration.py -q` *(skipped: torch not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689fc4dbfedc832daf1bef14605b9377