### PR TITLE
Use model evaluation functions with caching in challenge optimizer

### DIFF
--- a/pot/core/test_coverage_optimizer.py
+++ b/pot/core/test_coverage_optimizer.py
@@ -1,0 +1,41 @@
+import numpy as np
+from coverage_separation import CoverageSeparationOptimizer
+
+def dummy_model_linear(challenges):
+    return np.sum(challenges, axis=1) * 0.1
+
+def dummy_model_quadratic(challenges):
+    return np.sum(challenges ** 2, axis=1) * 0.1
+
+def dummy_model_mixed(challenges):
+    return np.sum(challenges * np.sin(challenges), axis=1) * 0.1
+
+def test_separation_improves_with_optimization():
+    """Ensure optimizer improves separation when models are provided."""
+    model_fns = {
+        "linear": dummy_model_linear,
+        "quadratic": dummy_model_quadratic,
+        "mixed": dummy_model_mixed,
+    }
+    optimizer = CoverageSeparationOptimizer(
+        input_dim=5,
+        n_challenges=20,
+        seed=0,
+        model_eval_functions=model_fns,
+    )
+
+    # Baseline using zero challenges yields no separation
+    baseline_challenges = np.zeros((20, 5))
+    baseline_sep = optimizer.evaluate_challenge_set(baseline_challenges).separation_score
+
+    optimized = optimizer.optimize_challenges(
+        coverage_weight=0.0,
+        separation_weight=1.0,
+        n_iterations=50,
+    )
+    optimized_sep = optimizer.evaluate_challenge_set(optimized).separation_score
+
+    print(f"Baseline separation: {baseline_sep:.4f}")
+    print(f"Optimized separation: {optimized_sep:.4f}")
+
+    assert optimized_sep >= baseline_sep


### PR DESCRIPTION
## Summary
- Replace simulated model responses with provided evaluation callables and add caching to avoid repeated evaluations.
- Add optimizer test using dummy model callables to confirm separation scores improve with optimization.

## Testing
- `pytest pot/core/test_coverage_optimizer.py -q`
- `pytest pot/security/test_fuzzy_verifier.py pot/security/test_provenance_auditor.py pot/security/test_token_normalizer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689fc4dd1070832d8c71b54e95c195df
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced simulated model responses with real model evaluation callables and added caching to avoid repeated evaluations. Separation scoring now reflects actual model outputs and runs faster during optimization.

- **New Features**
  - Optimizer accepts model_eval_functions and uses them for separation scoring.
  - Cached model responses by challenge set to skip redundant evaluations.
  - Added a test with dummy models to confirm separation improves after optimization.

- **Migration**
  - Provide model_eval_functions when creating CoverageSeparationOptimizer; a ValueError is raised otherwise.
  - Ensure each callable accepts challenges: np.ndarray (N, D) and returns a 1D np.ndarray of length N.

<!-- End of auto-generated description by cubic. -->

