### PR TITLE
feat: expand LM output distance metrics

### DIFF
--- a/pot/lm/test_output_distance.py
+++ b/pot/lm/test_output_distance.py
@@ -1,0 +1,41 @@
+from pot.lm.verifier import LMVerifier
+
+
+class DummyTokenizer:
+    def __init__(self):
+        self.vocab = {}
+        self.pad_token_id = 0
+        self.bos_token_id = 0
+        self.eos_token_id = 0
+
+    def encode(self, text, add_special_tokens=False):
+        tokens = text.lower().replace('.', '').split()
+        ids = []
+        for tok in tokens:
+            if tok not in self.vocab:
+                self.vocab[tok] = len(self.vocab) + 1
+            ids.append(self.vocab[tok])
+        return ids
+
+
+class DummyLM:
+    def __init__(self):
+        self.tok = DummyTokenizer()
+
+    def generate(self, prompt, max_new_tokens=64):
+        # Echo the prompt for simplicity
+        return prompt
+
+
+def test_paraphrase_vs_unrelated_distances():
+    lm = DummyLM()
+    verifier = LMVerifier(lm, use_sequential=False)
+
+    paraphrase_a = "the cat sat on the mat"
+    paraphrase_b = "on the mat sat the cat"
+    unrelated = "i love eating pizza"
+
+    for method in ["edit", "embedding", "fuzzy"]:
+        d_para = verifier.compute_output_distance(paraphrase_a, paraphrase_b, method=method)
+        d_unrel = verifier.compute_output_distance(paraphrase_a, unrelated, method=method)
+        assert d_para < d_unrel, f"{method} distance should be smaller for paraphrased outputs"


### PR DESCRIPTION
## Summary
- support fuzzy, exact, weighted, edit, and embedding-based distances in `LMVerifier.compute_output_distance`
- allow distance method selection in `evaluate_challenge` and `verify`
- add unit test comparing paraphrased and unrelated outputs across metrics

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fc4dec76c832d8fae23b2dd7d6d33
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Expands LM output distance metrics to include edit and embedding-based options alongside fuzzy, exact, and weighted. Adds a method selector to evaluate_challenge and verify, with a unit test that checks paraphrase vs. unrelated outputs.

- New Features
  - compute_output_distance now supports: fuzzy, exact, weighted, edit (normalized), and embedding (cosine over token-counts).
  - evaluate_challenge and verify accept a method parameter to choose the metric.
  - Added unit test ensuring paraphrased outputs score closer than unrelated ones for edit, embedding, and fuzzy.

<!-- End of auto-generated description by cubic. -->

