### PR TITLE
Add nonlinear drift tolerance model with cap and tests

### DIFF
--- a/pot/lm/test_time_tolerance.py
+++ b/pot/lm/test_time_tolerance.py
@@ -1,0 +1,75 @@
+import pytest
+from pot.lm.verifier import LMVerifier
+from typing import Dict
+
+
+class DummyTokenizer:
+    pad_token_id = None
+    bos_token_id = None
+    eos_token_id = None
+
+    def encode(self, text: str, add_special_tokens: bool = False):
+        return [ord(c) for c in text]
+
+
+class DummyLM:
+    def __init__(self, outputs: Dict[str, str]):
+        self.outputs = outputs
+        self.tok = DummyTokenizer()
+
+    def generate(self, prompt: str, max_new_tokens: int = 64):
+        return self.outputs.get(prompt, "")
+
+
+class DummyVerifier(LMVerifier):
+    def compute_output_distance(self, output1: str, output2: str, method: str = "fuzzy") -> float:
+        if output1 == output2:
+            return 0.0
+        if output1 == "close" and output2 == "ref":
+            return 0.12
+        if output1 == "far" and output2 == "ref":
+            return 0.2
+        return 1.0
+
+
+def test_verify_with_time_tolerance_nonlinear_cap():
+    reference = DummyLM({"p": "ref"})
+    verifier = DummyVerifier(reference)
+    challenges = [{"prompt": "p"}]
+
+    close_model = DummyLM({"p": "close"})
+    far_model = DummyLM({"p": "far"})
+
+    result_day0 = verifier.verify_with_time_tolerance(
+        close_model,
+        challenges,
+        base_tolerance=0.1,
+        days_elapsed=0,
+        drift_rate=0.1,
+        drift_model="quadratic",
+        max_tolerance=0.15,
+    )
+    assert not result_day0.accepted
+    assert "quadratic" in result_day0.metadata["time_tolerance"]["justification"]
+
+    result_close_day2 = verifier.verify_with_time_tolerance(
+        close_model,
+        challenges,
+        base_tolerance=0.1,
+        days_elapsed=2,
+        drift_rate=0.1,
+        drift_model="quadratic",
+        max_tolerance=0.15,
+    )
+    assert result_close_day2.accepted
+
+    result_far_day2 = verifier.verify_with_time_tolerance(
+        far_model,
+        challenges,
+        base_tolerance=0.1,
+        days_elapsed=2,
+        drift_rate=0.1,
+        drift_model="quadratic",
+        max_tolerance=0.15,
+    )
+    assert not result_far_day2.accepted

--- a/pot/lm/verifier.py
+++ b/pot/lm/verifier.py
@@ -281,11 +281,13 @@ class LMVerifier:
             return prompt
         return challenge.get("prompt", "Hello")
     
-    def verify_with_time_tolerance(self, model: LM, 
+    def verify_with_time_tolerance(self, model: LM,
                                   challenges: List[Dict[str, Any]],
                                   base_tolerance: float = 0.1,
                                   days_elapsed: int = 0,
-                                  drift_rate: float = 0.001) -> LMVerificationResult:
+                                  drift_rate: float = 0.001,
+                                  drift_model: str = "linear",
+                                  max_tolerance: Optional[float] = None) -> LMVerificationResult:
         """
         Verify with time-aware tolerance for version drift
         From paper Section 5 on handling model updates
@@ -295,14 +297,27 @@ class LMVerifier:
             challenges: Verification challenges
             base_tolerance: Base tolerance at time 0
             days_elapsed: Days since reference model snapshot
-            drift_rate: Expected drift per day
+            drift_rate: Expected drift parameter
+            drift_model: Drift adjustment model ('linear', 'quadratic', 'exponential')
+            max_tolerance: Optional cap on adjusted tolerance
             
         Returns:
             Verification result with adjusted tolerance
         """
-        # Adjust tolerance based on time elapsed
-        # τ(t) = τ_0 + λ * t
-        adjusted_tolerance = base_tolerance + drift_rate * days_elapsed
+        # Adjust tolerance based on time elapsed using specified drift model
+        if drift_model == "linear":
+            adjusted_tolerance = base_tolerance + drift_rate * days_elapsed
+        elif drift_model == "quadratic":
+            adjusted_tolerance = base_tolerance + drift_rate * (days_elapsed ** 2)
+        elif drift_model == "exponential":
+            adjusted_tolerance = base_tolerance * ((1 + drift_rate) ** days_elapsed)
+        else:
+            raise ValueError(f"Unknown drift_model: {drift_model}")
+
+        cap_applied = False
+        if max_tolerance is not None and adjusted_tolerance > max_tolerance:
+            adjusted_tolerance = max_tolerance
+            cap_applied = True
         
         # Run verification with adjusted tolerance
         result = self.verify(model, challenges, adjusted_tolerance)
@@ -312,7 +327,14 @@ class LMVerifier:
             "base_tolerance": base_tolerance,
             "days_elapsed": days_elapsed,
             "drift_rate": drift_rate,
-            "adjusted_tolerance": adjusted_tolerance
+            "drift_model": drift_model,
+            "max_tolerance": max_tolerance,
+            "adjusted_tolerance": adjusted_tolerance,
+            "justification": (
+                f"Tolerance adjusted using {drift_model} model with rate {drift_rate} "
+                f"over {days_elapsed} days" +
+                ("; capped at maximum tolerance " + str(max_tolerance) if cap_applied else "")
+            )
         }
         
         return result


### PR DESCRIPTION
## Summary
- extend `verify_with_time_tolerance` with nonlinear drift models (linear, quadratic, exponential) and optional maximum tolerance caps
- record drift model, cap, and justification in verification metadata
- add tests covering increasing elapsed days and ensuring tolerance-based acceptance and rejection

## Testing
- `PYTHONPATH=. pytest pot/lm/test_time_tolerance.py -q`
- `PYTHONPATH=. pytest pot/security/test_fuzzy_verifier.py pot/security/test_provenance_auditor.py pot/security/test_token_normalizer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689fc4dff700832daf3c9403d41aeed1
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds nonlinear drift tolerance models (linear, quadratic, exponential) and an optional max tolerance cap to verify_with_time_tolerance. Also records the chosen model and cap in metadata and adds tests that check acceptance and rejection over time.

- **New Features**
  - verify_with_time_tolerance now supports drift_model: linear, quadratic, exponential; applies max_tolerance cap when set; raises ValueError for unknown models.
  - Metadata now includes drift_model, max_tolerance, adjusted_tolerance, and a justification string indicating model, rate, days, and whether a cap was applied.
  - Added tests (pot/lm/test_time_tolerance.py) verifying quadratic drift behavior, cap enforcement, and metadata justification; covers acceptance of “close” and rejection of “far” outputs over increasing days.

<!-- End of auto-generated description by cubic. -->

