### PR TITLE
feat: add configurable logit wrapper

### DIFF
--- a/pot/core/attacks.py
+++ b/pot/core/attacks.py
@@ -1,7 +1,26 @@
 """Shared attack implementations for both vision and language models."""
 
 import numpy as np
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
+
+
+@dataclass
+class WrapperConfig:
+    """Configuration for logit wrapper transformations."""
+
+    temperature: float = 1.0
+    bias: float = 0.0
+
+    @classmethod
+    def from_dict(cls, config: Optional[Dict[str, float]] = None) -> "WrapperConfig":
+        """Create a config from a dictionary of parameters."""
+        if config is None:
+            return cls()
+        return cls(
+            temperature=config.get("temperature", 1.0),
+            bias=config.get("bias", 0.0),
+        )
 
 
 def targeted_finetune(model: Any, target_outputs: np.ndarray, epochs: int = 10) -> Any:

--- a/pot/lm/attacks.py
+++ b/pot/lm/attacks.py
@@ -5,13 +5,18 @@ from pot.core.attacks import (
     targeted_finetune,
     limited_distillation,
     wrapper_attack,
-    extraction_attack
+    extraction_attack,
+    WrapperConfig,
 )
 
-# LM-specific wrapper (for backward compatibility)
-def wrapper_map(outputs):
-    """Simple wrapper that passes through outputs."""
-    return outputs
+def wrapper_map(logits, config: WrapperConfig = WrapperConfig()):
+    """Apply temperature scaling and bias shift to logits."""
+    return logits / config.temperature + config.bias
+
+
+def inverse_wrapper_map(logits, config: WrapperConfig = WrapperConfig()):
+    """Reverses the transformation applied by ``wrapper_map``."""
+    return (logits - config.bias) * config.temperature
 
 # Re-export for backward compatibility
 __all__ = [
@@ -19,5 +24,7 @@ __all__ = [
     'limited_distillation', 
     'wrapper_attack', 
     'extraction_attack',
-    'wrapper_map'
+    'wrapper_map',
+    'inverse_wrapper_map',
+    'WrapperConfig',
 ]

--- a/pot/test_wrapper_map.py
+++ b/pot/test_wrapper_map.py
@@ -1,0 +1,24 @@
+import numpy as np
+
+from pot.core.attacks import WrapperConfig
+from pot.lm.attacks import wrapper_map as lm_wrapper_map, inverse_wrapper_map as lm_inverse_wrapper
+from pot.vision.attacks import wrapper_map as vis_wrapper_map, inverse_wrapper_map as vis_inverse_wrapper
+
+
+def check_transform(wrapper, inverse, cfg):
+    logits = np.array([1.0, -2.0, 3.0], dtype=float)
+    transformed = wrapper(logits, cfg)
+    expected = logits / cfg.temperature + cfg.bias
+    assert np.allclose(transformed, expected)
+    restored = inverse(transformed, cfg)
+    assert np.allclose(restored, logits)
+
+
+def test_lm_wrapper_transform_and_inverse():
+    cfg = WrapperConfig(temperature=2.0, bias=0.5)
+    check_transform(lm_wrapper_map, lm_inverse_wrapper, cfg)
+
+
+def test_vision_wrapper_transform_and_inverse():
+    cfg = WrapperConfig(temperature=0.5, bias=-1.0)
+    check_transform(vis_wrapper_map, vis_inverse_wrapper, cfg)

--- a/pot/vision/attacks.py
+++ b/pot/vision/attacks.py
@@ -5,15 +5,18 @@ from pot.core.attacks import (
     targeted_finetune,
     limited_distillation,
     wrapper_attack,
-    extraction_attack
+    extraction_attack,
+    WrapperConfig,
 )
 
-# Vision-specific wrapper (for backward compatibility)
-def wrapper_map(logits):
-    """Simple wrapper for logit transformation.
-    e.g., temperature scaling + bias shift placeholder
-    """
-    return logits
+def wrapper_map(logits, config: WrapperConfig = WrapperConfig()):
+    """Apply temperature scaling and bias shift to vision logits."""
+    return logits / config.temperature + config.bias
+
+
+def inverse_wrapper_map(logits, config: WrapperConfig = WrapperConfig()):
+    """Reverses the transformation applied by ``wrapper_map``."""
+    return (logits - config.bias) * config.temperature
 
 # Re-export for backward compatibility
 __all__ = [
@@ -21,5 +24,7 @@ __all__ = [
     'limited_distillation', 
     'wrapper_attack', 
     'extraction_attack',
-    'wrapper_map'
+    'wrapper_map',
+    'inverse_wrapper_map',
+    'WrapperConfig',
 ]


### PR DESCRIPTION
## Summary
- add configurable WrapperConfig for temperature scaling and bias shift
- apply logit transformation and inverse in LM and vision wrappers
- test logit transformation and invertibility

## Testing
- `PYTHONPATH=. pytest pot/test_wrapper_map.py pot/security/test_fuzzy_verifier.py pot/security/test_provenance_auditor.py pot/security/test_token_normalizer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689fc4e1ea84832dad2134982f4d094d
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a configurable logit wrapper for LM and vision models to apply temperature scaling and bias shift, with an inverse to restore original logits. This standardizes logit transforms and keeps wrapper_map calls backward-compatible via defaults.

- New Features
  - WrapperConfig (temperature, bias) with a from_dict helper.
  - wrapper_map and inverse_wrapper_map for LM and vision using WrapperConfig.
  - Tests verifying the transform and exact invertibility for both wrappers.

<!-- End of auto-generated description by cubic. -->

