### PR TITLE
Implement deterministic Perlin noise generation with tests

### DIFF
--- a/pot/vision/test_perlin_noise.py
+++ b/pot/vision/test_perlin_noise.py
@@ -1,0 +1,29 @@
+import torch
+import numpy as np
+
+from pot.vision.verifier import VisionVerifier
+from pot.vision.models import MockVisionModel
+
+
+def _get_verifier():
+    return VisionVerifier(MockVisionModel(), use_sequential=False, detect_wrappers=False)
+
+
+def test_perlin_noise_reproducible():
+    verifier = _get_verifier()
+    img1 = verifier._generate_perlin_noise((64, 64), octaves=2, scale=0.05, seed=123)
+    img2 = verifier._generate_perlin_noise((64, 64), octaves=2, scale=0.05, seed=123)
+    img3 = verifier._generate_perlin_noise((64, 64), octaves=2, scale=0.05, seed=124)
+    assert torch.allclose(img1, img2)
+    assert not torch.allclose(img1, img3)
+
+
+def test_perlin_noise_low_frequency():
+    verifier = _get_verifier()
+    img = verifier._generate_perlin_noise((128, 128), octaves=4, scale=0.05, seed=42)
+    arr = img.numpy()[0]
+    arr = arr - arr.mean()
+    power = np.abs(np.fft.rfft2(arr)) ** 2
+    low = power[:10, :10].sum()
+    high = power[10:, 10:].sum()
+    assert low > high


### PR DESCRIPTION
## Summary
- implement gradient-interpolated Perlin noise generation with deterministic seeding
- derive texture challenge seeds from master key and session nonce
- add tests ensuring Perlin noise reproducibility and dominant low-frequency content

## Testing
- `PYTHONPATH=. pytest pot/vision/test_perlin_noise.py -q`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fc4e366e4832dabb17b406181669d