### PR TITLE
Implement verification pipeline and integration test

### DIFF
--- a/scripts/run_verify.py
+++ b/scripts/run_verify.py
@@ -10,15 +10,23 @@ Emit:
 
 import argparse
 import yaml
-import json
 import numpy as np
 from pathlib import Path
 import sys
+import torch
+
+# Allow running as script from project root
 sys.path.append(str(Path(__file__).parent.parent))
 
-from pot.core.stats import t_statistic, far_frr, empirical_bernstein_radius
+from pot.core.canonicalize import canonicalize_logits
+from pot.core.challenge import ChallengeConfig, generate_challenges
+from pot.core.governance import new_session_nonce
+from pot.core.stats import (
+    empirical_bernstein_radius,
+    far_frr,
+    t_statistic,
+)
 from pot.core.logging import StructuredLogger
-from pot.core.governance import commit_message
 from pot.eval.metrics import dist_logits_l2, dist_kl
 
 def main():
@@ -28,51 +36,93 @@ def main():
     parser.add_argument("--n", type=int, default=256, help="Number of challenges")
     parser.add_argument("--output_dir", default="outputs", help="Output directory")
     args = parser.parse_args()
-    
+
     # Load config
     with open(args.config) as f:
         config = yaml.safe_load(f)
-    
-    # Setup logging
-    exp_name = config['experiment']
+
+    exp_name = config["experiment"]
     run_id = f"{args.challenge_family}_{args.n}"
     logger = StructuredLogger(f"{args.output_dir}/{exp_name}/{run_id}")
-    
-    # Placeholder: compute distances (would need actual model outputs)
-    # For skeleton, generate random distances
-    np.random.seed(42)
-    distances_h0 = np.random.normal(0.01, 0.005, args.n)  # Same model
-    distances_h1 = np.random.normal(0.1, 0.02, args.n)     # Different model
-    
-    # Compute statistics
-    t_stat = t_statistic(distances_h0)
-    
-    # FAR/FRR for different thresholds
-    for tau in config['verification']['tau_grid']:
-        far, frr = far_frr(distances_h0, distances_h1, tau)
-        
-        # Compute confidence radius
-        radius = empirical_bernstein_radius(distances_h0, delta=0.05)
-        
-        # Log result
+
+    # Load reference and test models
+    ref_model = torch.load(config["models"]["reference_path"], weights_only=False).eval()
+    test_model = torch.load(config["models"]["test_path"], weights_only=False).eval()
+
+    # Get challenge parameters from config
+    family_cfg = None
+    for fam in config["challenges"]["families"]:
+        if fam["family"] == args.challenge_family:
+            family_cfg = fam
+            break
+    if family_cfg is None:
+        raise ValueError(f"Challenge family {args.challenge_family} not found in config")
+
+    # Generate challenges
+    cfg = ChallengeConfig(
+        master_key_hex="0" * 64,
+        session_nonce_hex=new_session_nonce(),
+        n=args.n,
+        family=args.challenge_family,
+        params=family_cfg["params"],
+    )
+    challenge_data = generate_challenges(cfg)
+    items = challenge_data["items"]
+
+    metrics_map = {"logits_l2": dist_logits_l2, "kl": dist_kl}
+    selected_metrics = {m: metrics_map[m] for m in config["verification"]["distances"]}
+    dists_h0 = {m: [] for m in selected_metrics}
+    dists_h1 = {m: [] for m in selected_metrics}
+
+    def item_to_tensor(item):
+        vals = [item[k] for k in sorted(item.keys())]
+        return torch.tensor(vals, dtype=torch.float32).unsqueeze(0)
+
+    # Run models on challenges
+    for idx, item in enumerate(items):
+        x = item_to_tensor(item)
+        with torch.no_grad():
+            logits_ref = ref_model(x).squeeze(0).numpy()
+            logits_test = test_model(x).squeeze(0).numpy()
+        logits_ref = canonicalize_logits(logits_ref)
+        logits_test = canonicalize_logits(logits_test)
+
+        log_entry = {"challenge_index": idx}
+        for name, fn in selected_metrics.items():
+            d0 = fn(logits_ref, logits_ref)
+            d1 = fn(logits_ref, logits_test)
+            dists_h0[name].append(d0)
+            dists_h1[name].append(d1)
+            log_entry[name] = d1
+        logger.log_jsonl("distances.jsonl", log_entry)
+
+    # Convert distance lists to arrays
+    for name in selected_metrics:
+        dists_h0[name] = np.array(dists_h0[name])
+        dists_h1[name] = np.array(dists_h1[name])
+
+    # Use first metric for statistical estimates
+    primary_metric = next(iter(selected_metrics))
+    t_stat = t_statistic(dists_h1[primary_metric])
+
+    for tau in config["verification"]["tau_grid"]:
+        far, frr = far_frr(dists_h0[primary_metric], dists_h1[primary_metric], tau)
+        radius = empirical_bernstein_radius(dists_h1[primary_metric], delta=0.05)
+
         entry = {
             "run_id": run_id,
             "challenge_family": args.challenge_family,
             "n": args.n,
             "tau": tau,
-            "distances_mean": float(np.mean(distances_h0)),
-            "distances_std": float(np.std(distances_h0)),
             "T": t_stat,
             "far_hat": far,
             "frr_hat": frr,
             "confidence_radius": radius,
-            "config_snapshot": config
+            "config_snapshot": config,
         }
-        
         logger.log_jsonl("verify.jsonl", entry)
-        
         print(f"τ={tau}: FAR={far:.3f}, FRR={frr:.3f}, T={t_stat:.4f}")
-    
+
     print(f"Results saved to {args.output_dir}/{exp_name}/{run_id}/")
 
 if __name__ == "__main__":

--- a/tests/test_run_verify.py
+++ b/tests/test_run_verify.py
@@ -1,0 +1,74 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import torch
+import yaml
+
+
+def make_model(weight: float) -> torch.nn.Module:
+    linear = torch.nn.Linear(4, 2)
+    with torch.no_grad():
+        linear.weight.fill_(weight)
+        linear.bias.zero_()
+    return linear
+
+
+def test_run_verify_end_to_end(tmp_path):
+    ref_path = tmp_path / "ref.pt"
+    test_path = tmp_path / "test.pt"
+    torch.save(make_model(1.0), ref_path)
+    torch.save(make_model(1.1), test_path)
+
+    config = {
+        "experiment": "test_exp",
+        "models": {
+            "reference_path": str(ref_path),
+            "test_path": str(test_path),
+        },
+        "challenges": {
+            "families": [
+                {
+                    "family": "vision:freq",
+                    "n": 2,
+                    "params": {"freq_range": [0.5, 1.0], "contrast_range": [0.5, 0.5]},
+                }
+            ]
+        },
+        "verification": {"distances": ["logits_l2"], "tau_grid": [0.05]},
+    }
+    cfg_path = tmp_path / "config.yaml"
+    with open(cfg_path, "w") as f:
+        yaml.dump(config, f)
+
+    out_dir = tmp_path / "out"
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/run_verify.py",
+            "--config",
+            str(cfg_path),
+            "--challenge_family",
+            "vision:freq",
+            "--n",
+            "2",
+            "--output_dir",
+            str(out_dir),
+        ],
+        check=True,
+    )
+
+    run_path = out_dir / "test_exp" / "vision:freq_2"
+    distances_file = run_path / "distances.jsonl"
+    verify_file = run_path / "verify.jsonl"
+
+    assert distances_file.exists()
+    assert verify_file.exists()
+
+    distances_lines = list(open(distances_file))
+    assert len(distances_lines) == 2
+
+    summary = [json.loads(line) for line in open(verify_file)]
+    assert summary and "far_hat" in summary[0]
+


### PR DESCRIPTION
## Summary
- Load reference and test models in `run_verify.py`, run generated challenges, compute metrics, and log distances and summaries
- Add integration test exercising end-to-end verification workflow with mock models

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fc4e67978832da169c02020a99695