### PR TITLE
Compute attack cost from resource usage and add tests

### DIFF
--- a/scripts/run_attack.py
+++ b/scripts/run_attack.py
@@ -8,65 +8,109 @@ Logs attack cost, queries used, and resulting PoT distance distributions.
 """
 
 import argparse
+import time
 import yaml
-import numpy as np
 from pathlib import Path
 import sys
+
 sys.path.append(str(Path(__file__).parent.parent))
 
 from pot.core.logging import StructuredLogger
 
+# Cost model constants
+STEP_TIME = 0.05   # seconds per training step (simulated)
+STEP_COST = 0.1    # cost units per training step
+QUERY_COST = 0.01  # cost units per query
+TIME_COST = 0.001  # cost units per second
+
+
+def run_attack(config_path: str, attack: str, rho: float = 0.1,
+               budget: int = 10000, output_dir: str = "outputs"):
+    """Execute an attack simulation and log resource usage."""
+
+    # Load config
+    with open(config_path) as f:
+        config = yaml.safe_load(f)
+
+    exp_name = config["experiment"]
+    attack_id = f"{attack}_rho{rho}"
+    if attack == "distillation":
+        attack_id += f"_budget{budget}"
+    logger = StructuredLogger(f"{output_dir}/{exp_name}/attacks/{attack_id}")
+
+    print(f"Running {attack} attack with ρ={rho}")
+
+    total_n = sum(fam.get("n", 0) for fam in config.get("challenges", {}).get("families", []))
+
+    start = time.time()
+    if attack == "wrapper":
+        print("Applying wrapper mapping...")
+        training_steps = 0
+        queries_used = 0
+    elif attack == "targeted_finetune":
+        print(f"Fine-tuning on {rho*100:.0f}% leaked challenges...")
+        queries_used = int(rho * total_n)
+        training_steps = queries_used * 2  # assume 2 steps per leaked challenge
+    elif attack == "distillation":
+        print(f"Distilling with budget={budget} queries...")
+        queries_used = budget
+        training_steps = budget // 10  # assume 10 queries per step
+    else:
+        raise ValueError(f"Unknown attack type: {attack}")
+
+    # Simulated time spent on attack
+    time_sec = training_steps * STEP_TIME + (time.time() - start)
+    attack_cost = (
+        training_steps * STEP_COST
+        + time_sec * TIME_COST
+        + queries_used * QUERY_COST
+    )
+
+    entry = {
+        "attack_type": attack,
+        "rho": rho,
+        "budget": budget if attack == "distillation" else None,
+        "metrics": {
+            "training_steps": training_steps,
+            "time_sec": time_sec,
+            "queries_used": queries_used,
+            "attack_cost": attack_cost,
+        },
+        "config": config,
+    }
+
+    logger.log_jsonl("attack_log.jsonl", entry)
+
+    print(
+        f"Attack complete. Cost={attack_cost:.2f}, "
+        f"Steps={training_steps}, Time={time_sec:.2f}s, Queries={queries_used}"
+    )
+    print(f"Results saved to {output_dir}/{exp_name}/attacks/{attack_id}/")
+    return entry
+
+
 def main():
     parser = argparse.ArgumentParser(description="Run attack experiments")
     parser.add_argument("--config", required=True, help="Config YAML file")
-    parser.add_argument("--attack", choices=["wrapper", "targeted_finetune", "distillation"], 
-                       required=True, help="Attack type")
+    parser.add_argument(
+        "--attack", choices=["wrapper", "targeted_finetune", "distillation"],
+        required=True, help="Attack type",
+    )
     parser.add_argument("--rho", type=float, default=0.1, help="Leakage fraction")
-    parser.add_argument("--budget", type=int, default=10000, help="Query budget for distillation")
+    parser.add_argument(
+        "--budget", type=int, default=10000, help="Query budget for distillation"
+    )
     parser.add_argument("--output_dir", default="outputs", help="Output directory")
     args = parser.parse_args()
-    
-    # Load config
-    with open(args.config) as f:
-        config = yaml.safe_load(f)
-    
-    # Setup logging
-    exp_name = config['experiment']
-    attack_id = f"{args.attack}_rho{args.rho}"
-    logger = StructuredLogger(f"{args.output_dir}/{exp_name}/attacks/{attack_id}")
-    
-    print(f"Running {args.attack} attack with ρ={args.rho}")
-    
-    # Placeholder attack implementation
-    if args.attack == "wrapper":
-        print("Applying wrapper mapping...")
-        attack_cost = 0  # No training cost
-        queries_used = 0
-        
-    elif args.attack == "targeted_finetune":
-        print(f"Fine-tuning on {args.rho*100:.0f}% leaked challenges...")
-        attack_cost = args.rho * 1000  # Placeholder cost metric
-        queries_used = int(args.rho * 512)
-        
-    elif args.attack == "distillation":
-        print(f"Distilling with budget={args.budget} queries...")
-        attack_cost = args.budget * 0.01  # Placeholder cost metric
-        queries_used = args.budget
-    
-    # Log attack results
-    entry = {
-        "attack_type": args.attack,
-        "rho": args.rho,
-        "budget": args.budget if args.attack == "distillation" else None,
-        "attack_cost": attack_cost,
-        "queries_used": queries_used,
-        "config": config
-    }
-    
-    logger.log_jsonl("attack_log.jsonl", entry)
-    
-    print(f"Attack complete. Cost={attack_cost:.2f}, Queries={queries_used}")
-    print(f"Results saved to {args.output_dir}/{exp_name}/attacks/{attack_id}/")
+
+    run_attack(
+        args.config,
+        args.attack,
+        rho=args.rho,
+        budget=args.budget,
+        output_dir=args.output_dir,
+    )
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_run_attack.py
+++ b/tests/test_run_attack.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from scripts.run_attack import run_attack
+
+CONFIG = ROOT / "configs" / "lm_small.yaml"
+
+
+def test_wrapper_attack_metrics(tmp_path):
+    entry = run_attack(str(CONFIG), "wrapper", rho=0.0, output_dir=str(tmp_path))
+    metrics = entry["metrics"]
+    assert metrics["training_steps"] == 0
+    assert metrics["queries_used"] == 0
+    assert metrics["attack_cost"] >= 0
+
+
+def test_targeted_finetune_metrics_vary(tmp_path):
+    entry1 = run_attack(str(CONFIG), "targeted_finetune", rho=0.1, output_dir=str(tmp_path))
+    entry2 = run_attack(str(CONFIG), "targeted_finetune", rho=0.5, output_dir=str(tmp_path))
+    assert entry1["metrics"]["attack_cost"] < entry2["metrics"]["attack_cost"]
+    assert entry1["metrics"]["training_steps"] < entry2["metrics"]["training_steps"]
+
+
+def test_distillation_metrics_vary(tmp_path):
+    entry1 = run_attack(str(CONFIG), "distillation", budget=100, output_dir=str(tmp_path))
+    entry2 = run_attack(str(CONFIG), "distillation", budget=200, output_dir=str(tmp_path))
+    assert entry1["metrics"]["attack_cost"] < entry2["metrics"]["attack_cost"]
+    assert entry1["metrics"]["queries_used"] == 100
+    assert entry2["metrics"]["queries_used"] == 200


### PR DESCRIPTION
## Summary
- derive attack cost from simulated training steps, runtime, and query counts
- log per-attack metrics and resource usage via `StructuredLogger`
- add tests for wrapper, targeted fine-tune, and distillation attacks to ensure metrics respond to parameters

## Testing
- `pytest tests/test_run_attack.py`


------
https://chatgpt.com/codex/tasks/task_e_689fc4e7511c832dbbde65519cee0848
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Compute attack cost from training steps, runtime, and queries, and log per-attack metrics with StructuredLogger. Added tests to ensure costs and metrics scale with rho and budget.

- **New Features**
  - Derived attack_cost = steps*STEP_COST + time*TIME_COST + queries*QUERY_COST; logged training_steps, time_sec, queries_used, and attack_cost to attack_log.jsonl.
  - Added run_attack(config, attack, rho, budget, output_dir) that builds a consistent attack_id (includes budget for distillation) and returns a metrics entry; metrics scale by attack type (wrapper: no steps/queries, targeted_finetune: scales with rho, distillation: scales with budget).

- **Refactors**
  - Extracted core logic into run_attack and simplified CLI to delegate to it.
  - Replaced placeholder costs with a simple cost model and simulated timing.

<!-- End of auto-generated description by cubic. -->

