### PR TITLE
Load leakage results from logs and add plotting test

### DIFF
--- a/tests/test_run_plots.py
+++ b/tests/test_run_plots.py
@@ -1,0 +1,40 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_leakage_plot_generation(tmp_path):
+    exp_dir = tmp_path / "exp"
+    exp_dir.mkdir()
+
+    log_file = exp_dir / "leakage_log.jsonl"
+    entries = [
+        {"rho": 0.0, "detection_rate": 1.0},
+        {"rho": 0.25, "detection_rate": 0.8},
+    ]
+    with open(log_file, "w") as f:
+        for e in entries:
+            f.write(json.dumps(e) + "\n")
+
+    env = os.environ.copy()
+    env["MPLBACKEND"] = "Agg"
+
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/run_plots.py",
+            "--exp_dir",
+            str(exp_dir),
+            "--plot_type",
+            "leakage",
+            "--input_files",
+            str(log_file),
+        ],
+        check=True,
+        env=env,
+        cwd=Path(__file__).resolve().parents[1],
+    )
+
+    assert (exp_dir / "leakage_curve.png").exists()


### PR DESCRIPTION
## Summary
- allow run_plots to accept specific result files via `--input_files`
- read leakage `rho` and detection rates from JSONL logs and plot with correct axis limits
- add regression test generating a temporary log and ensuring leakage curve is created

## Testing
- `pytest tests/test_run_plots.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689fc4eb5238832daa325a01aefd5084