### PR TITLE
Add CPU-only execution option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ htmlcov/
 *.npz
 data/
 models/
+!pot/models/
 checkpoints/
 
 # Logs

--- a/README.md
+++ b/README.md
@@ -13,6 +13,19 @@ Reproduce with: `bash run_all.sh` (details in [EXPERIMENTS.md](EXPERIMENTS.md)).
 
 Note: "Security components" under `pot/security/` are prototypes; core verification uses `pot/core/*` and `scripts/run_*` only.
 
+### Running on CPU
+
+The main run scripts support a `--cpu-only` flag that disables CUDA initialization and forces all models to load on the CPU. This is useful when no GPU is available or for debugging purposes.
+
+Example CPU-only invocations:
+
+```bash
+python scripts/run_grid.py --config configs/vision_cifar10.yaml --exp E1 --cpu-only
+python scripts/run_verify.py --config configs/vision_cifar10.yaml --challenge_family vision:texture --n 256 --cpu-only
+```
+
+The same flag is available for other scripts such as `run_attack.py`.
+
 ## Relation to Proof-of-Learning
 
 PoT offers statistical model-identity checks and complements cryptographic Proof-of-Learning (PoL) systems that attest to training provenance. PoL schemes require access to training traces or commitments and have recently improved via polynomial commitments and gradient compression, while PoT operates post-hoc on black-box models. Combining PoT with PoL can bind behavioral fingerprints to verifiable training histories.

--- a/pot/models/__init__.py
+++ b/pot/models/__init__.py
@@ -1,0 +1,19 @@
+"""Utility helpers for loading models with optional CPU-only execution."""
+
+from __future__ import annotations
+
+import torch
+
+
+def load_model(path: str, cpu_only: bool = False):
+    """Load a PyTorch model from ``path``.
+
+    Args:
+        path: Path to the model checkpoint.
+        cpu_only: If True, force loading on CPU and avoid CUDA initialization.
+
+    Returns:
+        The loaded model.
+    """
+    map_location = "cpu" if cpu_only else None
+    return torch.load(path, weights_only=False, map_location=map_location)

--- a/scripts/run_attack.py
+++ b/scripts/run_attack.py
@@ -46,7 +46,17 @@ def main():
         help="Query budget for distillation or extraction attacks",
     )
     parser.add_argument("--output_dir", default="outputs", help="Output directory")
+    parser.add_argument(
+        "--cpu-only",
+        action="store_true",
+        help="Run on CPU only and avoid CUDA initialization",
+    )
     args = parser.parse_args()
+
+    if args.cpu_only:
+        import os
+
+        os.environ["CUDA_VISIBLE_DEVICES"] = ""
     
     # Load config
     with open(args.config) as f:


### PR DESCRIPTION
## Summary
- add pot.models helper to load models on CPU and skip CUDA init
- support `--cpu-only` flag in run scripts
- document CPU-only usage in README

## Testing
- `pytest -q` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68a0038ee98c832dba392094360f7b12
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add a CPU-only execution option across run scripts to avoid CUDA init and load models on the CPU. Useful for machines without GPUs and for debugging.

- **New Features**
  - --cpu-only flag in run_grid.py, run_verify.py, and run_attack.py; disables CUDA via CUDA_VISIBLE_DEVICES="" and forces CPU device.
  - New pot.models.load_model helper to load checkpoints with map_location="cpu"; used in run_verify.
  - run_grid updates: ResourceMonitor and load_production_model respect cpu_only, skip CUDA metrics, and use CPU device/device_map.
  - README updated with CPU-only usage examples.
  - .gitignore updated to keep pot/models tracked.

<!-- End of auto-generated description by cubic. -->

