### PR TITLE
Handle missing optional dependencies

### DIFF
--- a/experimental_report.py
+++ b/experimental_report.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, asdict
 from datetime import datetime
 import sys
 import os
+import warnings
 
 # Add parent directory to path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__ if "__file__" in locals() else sys.argv[0])))
@@ -25,8 +26,9 @@ try:
     import matplotlib.pyplot as plt
     import seaborn as sns
     HAS_VISUALIZATION = True
-except ImportError:
+except ImportError as e:
     HAS_VISUALIZATION = False
+    warnings.warn(f"Optional dependency missing ({e}); visualization disabled.")
 
 @dataclass
 class PerformanceMetrics:
@@ -81,7 +83,7 @@ class ResourceProfiler:
             if torch.cuda.is_available():
                 torch.cuda.reset_peak_memory_stats()
         except ImportError:
-            pass
+            warnings.warn("PyTorch not available; GPU metrics will be skipped.")
     
     def sample_resources(self):
         """Sample current resource usage"""
@@ -107,7 +109,7 @@ class ResourceProfiler:
                 gpu_memory = torch.cuda.memory_allocated() / 1024 / 1024  # MB
                 self.gpu_samples.append((elapsed, gpu_memory))
         except ImportError:
-            pass
+            warnings.warn("PyTorch not available; GPU metrics will be skipped.")
     
     def record_query(self):
         """Record a query being made"""
@@ -130,7 +132,7 @@ class ResourceProfiler:
             if torch.cuda.is_available():
                 peak_gpu_mb = torch.cuda.max_memory_allocated() / 1024 / 1024
         except ImportError:
-            pass
+            warnings.warn("PyTorch not available; GPU metrics will be zero.")
         
         # Throughput
         throughput = self.query_count / max(runtime, 0.001)
@@ -190,6 +192,7 @@ class ExperimentalReporter:
                 info["gpu_available"] = False
         except ImportError:
             info["torch_available"] = False
+            warnings.warn("PyTorch not available; GPU information omitted.")
             
         return info
         

--- a/pot/core/attacks.py
+++ b/pot/core/attacks.py
@@ -11,6 +11,8 @@ except ImportError:
     torch = None
     nn = None
     HAS_TORCH = False
+    import warnings
+    warnings.warn("PyTorch not available; attack utilities will be limited.")
 
 
 def targeted_finetune(

--- a/pot/core/jsonenc.py
+++ b/pot/core/jsonenc.py
@@ -11,6 +11,8 @@ try:
 except ImportError:
     torch = None
     HAS_TORCH = False
+    import warnings
+    warnings.warn("PyTorch not available; JSON encoding of tensors will be disabled.")
 
 
 class NpTorchEncoder(json.JSONEncoder):

--- a/pot/core/utils.py
+++ b/pot/core/utils.py
@@ -15,6 +15,8 @@ try:
 except ImportError:
     torch = None
     HAS_TORCH = False
+    import warnings
+    warnings.warn("PyTorch not available; some utility functions will degrade.")
 
 
 def set_reproducibility(seed: int = 42):
@@ -39,14 +41,15 @@ def set_deterministic(seed: int = 0):
     # PyTorch if available
     if HAS_TORCH and torch is not None:
         torch.manual_seed(seed)
-        torch.cuda.manual_seed(seed)
-        torch.cuda.manual_seed_all(seed)
-        
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed(seed)
+            torch.cuda.manual_seed_all(seed)
+
         # Set deterministic algorithms
         torch.use_deterministic_algorithms(True, warn_only=True)
-        
+
         # Disable cudnn benchmarking for determinism
-        if hasattr(torch.backends, 'cudnn'):
+        if torch.cuda.is_available() and hasattr(torch.backends, 'cudnn'):
             torch.backends.cudnn.deterministic = True
             torch.backends.cudnn.benchmark = False
 


### PR DESCRIPTION
## Summary
- Add PyTorch and CUDA availability checks to `run_all_quick.sh` and improve logging for failed imports
- Warn when optional dependencies like PyTorch are missing in core utilities and experimental report modules
- Guard deterministic utilities against absent CUDA

## Testing
- `pytest` *(fails: 17 errors during collection)*
- `bash run_all_quick.sh` *(fails: some modules like numpy missing, warnings shown)*
- `python -m py_compile experimental_report.py pot/core/attacks.py pot/core/jsonenc.py pot/core/utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68a0038eea10832da52c94119d7a6f4b
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improve resilience when PyTorch/CUDA are missing by adding checks and graceful fallbacks across the codebase, plus clearer warnings and logs in run_all_quick.sh. Prevent crashes from optional imports and skip GPU work when unsupported.

- **New Features**
  - run_all_quick.sh: detect PyTorch and CUDA; print warnings; capture command output; treat ImportError as a warning while keeping the run going.
  - experimental_report.py: warn when visualization libs or PyTorch are missing; skip GPU metrics and set them to zero when needed; note missing GPU info in system report.
  - pot/core/attacks.py and pot/core/jsonenc.py: warn when PyTorch is absent; limit attack utilities and disable tensor JSON encoding gracefully.

- **Bug Fixes**
  - pot/core/utils.py: guard torch.cuda calls and cuDNN settings behind torch.cuda.is_available to avoid errors on CPU-only hosts.
  - Replace silent passes with explicit warnings to make missing optional deps visible without breaking execution.

<!-- End of auto-generated description by cubic. -->

