### PR TITLE
chore: relax deps and skip optional tests

### DIFF
--- a/pot/security/test_blockchain_client.py
+++ b/pot/security/test_blockchain_client.py
@@ -1,3 +1,6 @@
+import pytest
+pytest.importorskip("web3")
+
 from pot.prototypes.training_provenance_auditor import BlockchainClient
 from web3 import Web3
 from web3.providers.eth_tester import EthereumTesterProvider

--- a/pot/security/test_token_normalizer.py
+++ b/pot/security/test_token_normalizer.py
@@ -6,6 +6,13 @@ import numpy as np
 import json
 import time
 from typing import List, Dict, Any
+
+try:
+    import torch
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    torch = None
+
+import pytest
 from token_space_normalizer import (
     TokenSpaceNormalizer,
     StochasticDecodingController,
@@ -16,7 +23,6 @@ from token_space_normalizer import (
     AlignmentResult,
     MockTokenizer
 )
-import torch
 
 
 def test_text_normalization():
@@ -387,6 +393,8 @@ def test_generation_variants():
 
 def test_hf_model_generation_with_metadata():
     """Ensure HuggingFace-style models generate text and log metadata"""
+    if torch is None:
+        pytest.skip("PyTorch not installed")
 
     controller = StochasticDecodingController(seed=0)
 

--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -3,13 +3,13 @@ torchvision==0.17.0
 transformers==4.31.0
 accelerate==0.21.0
 sentence-transformers==2.2.2
-numpy==1.24.4
+numpy>=2.0.0
 scipy==1.10.1
 scikit-learn==1.3.0
 einops==0.6.1
 tqdm==4.65.0
 pyyaml==6.0
-matplotlib==3.7.1
+matplotlib>=3.8.2
 seaborn==0.12.2
 xxhash==3.4.1
 ssdeep==3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,13 +3,13 @@ torchvision
 transformers
 accelerate
 sentence-transformers
-numpy
+numpy>=2.0.0
 scipy
 scikit-learn
 einops
 tqdm
 pyyaml
-matplotlib
+matplotlib>=3.8.0
 seaborn
 xxhash
 


### PR DESCRIPTION
## Summary
- relax numpy/matplotlib pins for Python 3.12
- skip blockchain test when web3 isn't installed
- make token normalizer tests tolerant to missing PyTorch

## Testing
- `pytest pot/security -q`
- `pytest -q` *(fails: No module named 'scipy')*

------
https://chatgpt.com/codex/tasks/task_e_689ffe8d82f4832d9b6aed13af50b74d