### PR TITLE
Document CPU-only setup for PoT pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,26 @@ Reproduce with: `bash run_all.sh` (details in [EXPERIMENTS.md](EXPERIMENTS.md)).
 
 Note: "Security components" under `pot/security/` are prototypes; core verification uses `pot/core/*` and `scripts/run_*` only.
 
-### Running on CPU
+### Running without CUDA
 
-The main run scripts support a `--cpu-only` flag that disables CUDA initialization and forces all models to load on the CPU. This is useful when no GPU is available or for debugging purposes.
+Install CPU-only dependencies and execute the quick validation script:
 
-Example CPU-only invocations:
+```bash
+pip install -r requirements-cpu.txt
+bash run_all_quick.sh
+```
+
+The script automatically detects the absence of CUDA and skips GPU checks.
+All experiment runners also support a `--cpu-only` flag to force models onto
+the CPU, for example:
 
 ```bash
 python scripts/run_grid.py --config configs/vision_cifar10.yaml --exp E1 --cpu-only
 python scripts/run_verify.py --config configs/vision_cifar10.yaml --challenge_family vision:texture --n 256 --cpu-only
 ```
 
-The same flag is available for other scripts such as `run_attack.py`.
+This setup enables running the core PoT pipeline on machines without
+NVIDIA GPUs.
 
 ## Relation to Proof-of-Learning
 

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -1,0 +1,16 @@
+--extra-index-url https://download.pytorch.org/whl/cpu
+
+torch==2.2.0
+torchvision==0.17.0
+transformers
+accelerate
+sentence-transformers
+numpy>=2.0.0
+scipy
+scikit-learn
+einops
+tqdm
+pyyaml
+matplotlib>=3.8.0
+seaborn
+xxhash


### PR DESCRIPTION
## Summary
- Add a requirements-cpu.txt for running PoT on machines without CUDA
- Document CPU-only workflow in README, including quick validation script

## Testing
- `pip install -r requirements-cpu.txt`
- `bash run_all_quick.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a0737fd854832d91272972135936e9