### PR TITLE
Ensure pytest dependency for PoT validator

### DIFF
--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -14,3 +14,4 @@ seaborn==0.12.2
 xxhash==3.4.1
 ssdeep==3.4
 py-tlsh==4.7.2
+pytest>=7.0.0

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -14,3 +14,4 @@ pyyaml
 matplotlib>=3.8.0
 seaborn
 xxhash
+pytest>=7.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ xxhash
 # Required for fuzzy hashing (core PoT functionality)
 ssdeep
 py-tlsh
+pytest>=7.0.0

--- a/run_all.sh
+++ b/run_all.sh
@@ -69,6 +69,7 @@ check_dependencies() {
     print_info "Checking required packages..."
     
     ${PYTHON} -c "import numpy" 2>/dev/null && print_success "NumPy installed" || print_error "NumPy not found"
+    ${PYTHON} -c "import pytest" 2>/dev/null && print_success "PyTest installed" || print_error "PyTest not found"
     
     # Check optional dependencies
     ${PYTHON} -c "import torch" 2>/dev/null && print_success "PyTorch installed" || print_info "PyTorch not found (optional)"


### PR DESCRIPTION
## Summary
- include `pytest` in all requirement files so validation tests can run
- verify `pytest` presence in `run_all.sh`

## Testing
- `bash run_all.sh` *(fails: experimental validation incomplete but dependency checks and component tests pass)*
- `pytest -q` *(fails: multiple errors during collection due to missing optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a076ee16fc832d843e7f5cbb877457