### PR TITLE
Add environment checks and document configuration variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,24 @@ bash scripts/run_standard_validation.sh
 bash scripts/run_all_quick.sh
 ```
 
+### Environment Variables
+
+The scripts honor several environment variables that let you customize execution:
+
+| Variable | Description | Default |
+|---------|-------------|---------|
+| `PYTHON` | Python interpreter to use | `python3` |
+| `RESULTS_DIR` | Where validation logs and artifacts are stored | `experimental_results` |
+| `PYTHONPATH` | Additional paths for Python imports | Repository root |
+| `ZK_MODE` | Zero-knowledge proof mode (`dev`, `benchmark`, `production`) | unset |
+
+Example:
+
+```bash
+export ZK_MODE=production
+bash scripts/run_standard_validation.sh
+```
+
 ### Validate Paper Claims
 
 ```bash

--- a/scripts/run_all.sh
+++ b/scripts/run_all.sh
@@ -73,7 +73,20 @@ check_dependencies() {
     
     ${PYTHON} -c "import numpy" 2>/dev/null && print_success "NumPy installed" || print_error "NumPy not found"
     ${PYTHON} -c "import pytest" 2>/dev/null && print_success "PyTest installed" || print_error "PyTest not found"
-    
+    ${PYTHON} -c "import yaml" 2>/dev/null && print_success "PyYAML installed" || {
+        print_error "PyYAML not found"
+        print_info "Install with: pip install pyyaml"
+    }
+
+    command -v rustc >/dev/null 2>&1 && print_success "rustc installed" || {
+        print_error "rustc not found"
+        print_info "Install Rust toolchain: https://www.rust-lang.org/tools/install"
+    }
+    command -v cargo >/dev/null 2>&1 && print_success "cargo installed" || {
+        print_error "cargo not found"
+        print_info "Install Rust toolchain: https://www.rust-lang.org/tools/install"
+    }
+
     # Check optional dependencies
     ${PYTHON} -c "import torch" 2>/dev/null && print_success "PyTorch installed" || print_info "PyTorch not found (optional)"
     ${PYTHON} -c "import transformers" 2>/dev/null && print_success "Transformers installed" || print_info "Transformers not found (optional)"


### PR DESCRIPTION
## Summary
- validate PyYAML, `rustc`, and `cargo` in `scripts/run_all.sh` with install guidance
- document `PYTHON`, `RESULTS_DIR`, `PYTHONPATH`, and `ZK_MODE` variables in installation instructions

## Testing
- `PYTHONPATH=$PWD pytest tests/test_api_verification.py -q` *(fails: ModuleNotFoundError: No module named 'pot.core.logging')*

------
https://chatgpt.com/codex/tasks/task_e_68a5d27ae7a4832daeca0fcc94472a5d