### PR TITLE
Update SGD statement root field names

### DIFF
--- a/benchmarks/zk_performance.py
+++ b/benchmarks/zk_performance.py
@@ -82,8 +82,8 @@ class ZKPerformanceBenchmark:
             )
             
             statement = SGDStepStatement(
-                weights_before_root=b"before" * 8,
-                weights_after_root=b"after" * 8,
+                W_t_root=b"before" * 8,
+                W_t1_root=b"after" * 8,
                 batch_root=b"batch" * 8,
                 hparams_hash=b"hparams" * 4,
                 step_number=1,
@@ -178,8 +178,8 @@ class ZKPerformanceBenchmark:
             )
             
             full_statement = SGDStepStatement(
-                weights_before_root=b"before" * 8,
-                weights_after_root=b"after" * 8,
+                W_t_root=b"before" * 8,
+                W_t1_root=b"after" * 8,
                 batch_root=b"batch" * 8,
                 hparams_hash=b"hparams" * 4,
                 step_number=1,
@@ -239,8 +239,8 @@ class ZKPerformanceBenchmark:
                 )
                 
                 statement = SGDStepStatement(
-                    weights_before_root=f"before_{i}".encode() * 4,
-                    weights_after_root=f"after_{i}".encode() * 4,
+                    W_t_root=f"before_{i}".encode() * 4,
+                    W_t1_root=f"after_{i}".encode() * 4,
                     batch_root=f"batch_{i}".encode() * 4,
                     hparams_hash=b"hparams" * 4,
                     step_number=i,

--- a/examples/optimized_zk_demo.py
+++ b/examples/optimized_zk_demo.py
@@ -160,8 +160,8 @@ def demonstrate_parallel_proving():
     tasks = []
     for i in range(10):
         statement = SGDStepStatement(
-            weights_before_root=f"before_{i}".encode() * 4,
-            weights_after_root=f"after_{i}".encode() * 4,
+            W_t_root=f"before_{i}".encode() * 4,
+            W_t1_root=f"after_{i}".encode() * 4,
             batch_root=f"batch_{i}".encode() * 4,
             hparams_hash=b"hparams" * 4,
             step_number=i,
@@ -276,8 +276,8 @@ def demonstrate_streaming_prover():
     
     for i in range(20):
         statement = SGDStepStatement(
-            weights_before_root=f"before_{i}".encode() * 4,
-            weights_after_root=f"after_{i}".encode() * 4,
+            W_t_root=f"before_{i}".encode() * 4,
+            W_t1_root=f"after_{i}".encode() * 4,
             batch_root=f"batch_{i}".encode() * 4,
             hparams_hash=b"hparams" * 4,
             step_number=i,

--- a/pot/zk/test_integration_full.py
+++ b/pot/zk/test_integration_full.py
@@ -298,8 +298,8 @@ class TestEndToEndIntegration:
             from pot.zk.zk_types import SGDStepStatement, SGDStepWitness
             
             statement = SGDStepStatement(
-                weights_before_root=f"before_{i}".encode() * 4,
-                weights_after_root=f"after_{i}".encode() * 4,
+                W_t_root=f"before_{i}".encode() * 4,
+                W_t1_root=f"after_{i}".encode() * 4,
                 batch_root=f"batch_{i}".encode() * 4,
                 hparams_hash=b"hparams" * 4,
                 step_number=i,

--- a/pot/zk/test_security.py
+++ b/pot/zk/test_security.py
@@ -49,8 +49,8 @@ class TestInvalidWitnesses:
         )
         
         statement = SGDStepStatement(
-            weights_before_root=b"before" * 8,
-            weights_after_root=b"after" * 8,
+            W_t_root=b"before" * 8,
+            W_t1_root=b"after" * 8,
             batch_root=b"batch" * 8,
             hparams_hash=b"hparams" * 4,
             step_number=1,
@@ -89,8 +89,8 @@ class TestInvalidWitnesses:
         )
         
         statement = SGDStepStatement(
-            weights_before_root=b"before" * 8,
-            weights_after_root=b"after" * 8,
+            W_t_root=b"before" * 8,
+            W_t1_root=b"after" * 8,
             batch_root=b"batch" * 8,
             hparams_hash=b"hparams" * 4,
             step_number=1,
@@ -249,8 +249,8 @@ class TestTamperingResistance:
         )
         
         statement1 = SGDStepStatement(
-            weights_before_root=b"before1" * 8,
-            weights_after_root=b"after1" * 8,
+            W_t_root=b"before1" * 8,
+            W_t1_root=b"after1" * 8,
             batch_root=b"batch1" * 8,
             hparams_hash=b"hparams" * 4,
             step_number=1,
@@ -262,8 +262,8 @@ class TestTamperingResistance:
         
         # Create different statement
         statement2 = SGDStepStatement(
-            weights_before_root=b"before2" * 8,
-            weights_after_root=b"after2" * 8,
+            W_t_root=b"before2" * 8,
+            W_t1_root=b"after2" * 8,
             batch_root=b"batch2" * 8,
             hparams_hash=b"hparams" * 4,
             step_number=2,
@@ -296,8 +296,8 @@ class TestTamperingResistance:
         proofs = []
         for step in range(3):
             statement = SGDStepStatement(
-                weights_before_root=b"before" * 8,
-                weights_after_root=b"after" * 8,
+                W_t_root=b"before" * 8,
+                W_t1_root=b"after" * 8,
                 batch_root=b"batch" * 8,
                 hparams_hash=b"hparams" * 4,
                 step_number=step,  # Different step numbers
@@ -347,8 +347,8 @@ class TestZeroKnowledgeProperty:
         
         # Same statement (public inputs)
         statement = SGDStepStatement(
-            weights_before_root=b"before" * 8,
-            weights_after_root=b"after" * 8,
+            W_t_root=b"before" * 8,
+            W_t1_root=b"after" * 8,
             batch_root=b"batch" * 8,
             hparams_hash=b"hparams" * 4,
             step_number=1,
@@ -398,8 +398,8 @@ class TestZeroKnowledgeProperty:
         )
         
         statement = SGDStepStatement(
-            weights_before_root=b"before" * 8,
-            weights_after_root=b"after" * 8,
+            W_t_root=b"before" * 8,
+            W_t1_root=b"after" * 8,
             batch_root=b"batch" * 8,
             hparams_hash=b"hparams" * 4,
             step_number=1,
@@ -492,8 +492,8 @@ class TestZeroKnowledgeProperty:
             )
             
             statement = SGDStepStatement(
-                weights_before_root=b"before" * 8,
-                weights_after_root=b"after" * 8,
+                W_t_root=b"before" * 8,
+                W_t1_root=b"after" * 8,
                 batch_root=b"batch" * 8,
                 hparams_hash=b"hparams" * 4,
                 step_number=1,
@@ -535,8 +535,8 @@ class TestSoundnessAndCompleteness:
             )
             
             statement = SGDStepStatement(
-                weights_before_root=b"before" * 8,
-                weights_after_root=b"after" * 8,
+                W_t_root=b"before" * 8,
+                W_t1_root=b"after" * 8,
                 batch_root=b"batch" * 8,
                 hparams_hash=b"hparams" * 4,
                 step_number=1,
@@ -621,8 +621,8 @@ class TestSoundnessAndCompleteness:
         invalid_witnesses.append(wrong_witness2)
         
         statement = SGDStepStatement(
-            weights_before_root=b"before" * 8,
-            weights_after_root=b"after" * 8,
+            W_t_root=b"before" * 8,
+            W_t1_root=b"after" * 8,
             batch_root=b"batch" * 8,
             hparams_hash=b"hparams" * 4,
             step_number=1,
@@ -640,8 +640,8 @@ class TestSoundnessAndCompleteness:
         
         # Create statement
         statement = SGDStepStatement(
-            weights_before_root=b"fixed_before" * 4,
-            weights_after_root=b"fixed_after" * 4,
+            W_t_root=b"fixed_before" * 4,
+            W_t1_root=b"fixed_after" * 4,
             batch_root=b"fixed_batch" * 4,
             hparams_hash=b"fixed_hparams" * 2,
             step_number=42,

--- a/tests/test_zk_integration.py
+++ b/tests/test_zk_integration.py
@@ -416,8 +416,8 @@ def test_zk_pytest_compatibility():
     )
     
     statement = SGDStepStatement(
-        weights_before_root=b"before" * 8,
-        weights_after_root=b"after" * 8,
+        W_t_root=b"before" * 8,
+        W_t1_root=b"after" * 8,
         batch_root=b"batch" * 8,
         hparams_hash=b"hparams" * 4,
         step_number=1,

--- a/tests/test_zk_validation_suite.py
+++ b/tests/test_zk_validation_suite.py
@@ -66,8 +66,8 @@ class TestZKValidationSuite:
         )
         
         statement = SGDStepStatement(
-            weights_before_root=b"before" * 8,
-            weights_after_root=b"after" * 8,
+            W_t_root=b"before" * 8,
+            W_t1_root=b"after" * 8,
             batch_root=b"batch" * 8,
             hparams_hash=b"hparams" * 4,
             step_number=1,
@@ -163,8 +163,8 @@ class TestZKValidationSuite:
             )
             
             statement = SGDStepStatement(
-                weights_before_root=f"before_{i}".encode() * 4,
-                weights_after_root=f"after_{i}".encode() * 4,
+                W_t_root=f"before_{i}".encode() * 4,
+                W_t1_root=f"after_{i}".encode() * 4,
                 batch_root=f"batch_{i}".encode() * 4,
                 hparams_hash=b"hparams" * 4,
                 step_number=i,
@@ -383,8 +383,8 @@ class TestZKValidationSuite:
             )
             
             statement = SGDStepStatement(
-                weights_before_root=f"before_{i}".encode() * 4,
-                weights_after_root=f"after_{i}".encode() * 4,
+                W_t_root=f"before_{i}".encode() * 4,
+                W_t1_root=f"after_{i}".encode() * 4,
                 batch_root=f"batch_{i}".encode() * 4,
                 hparams_hash=b"hparams" * 4,
                 step_number=i,


### PR DESCRIPTION
## Summary
- replace outdated `weights_before_root`/`weights_after_root` usage with new `W_t_root`/`W_t1_root`
- adjust tests, benchmarks, and examples to construct `SGDStepStatement` using updated fields

## Testing
- `python -m py_compile benchmarks/zk_performance.py examples/optimized_zk_demo.py pot/zk/test_integration_full.py pot/zk/test_security.py`
- `pytest tests/test_zk_validation_suite.py tests/test_zk_integration.py pot/zk/test_security.py pot/zk/test_integration_full.py -q` *(fails: ImportError: cannot import name 'compute_weight_commitment'; ModuleNotFoundError: No module named 'pot.testing.mock_blockchain')*
- `pytest tests/test_zk_validation_suite.py tests/test_zk_integration.py -q` *(fails: AttributeError: 'WitnessCache' object has no attribute 'clear'; FileNotFoundError: Rust prover binary not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d75c2610832db3ce315ade32cb46