### PR TITLE
Relocate PoT attack wrapper and document usage

### DIFF
--- a/scripts/attack/README.md
+++ b/scripts/attack/README.md
@@ -1,0 +1,21 @@
+# Attack Utilities
+
+`pot_attack.sh` is a thin wrapper around the `pot.cli.attack_cli` module.
+It sets up the Python path and provides easy command-line access to the
+attack evaluation tools in this repository.
+
+## Usage
+
+Run the script from the repository root:
+
+```bash
+bash scripts/attack/pot_attack.sh run-attacks -m model.pth -s standard
+bash scripts/attack/pot_attack.sh benchmark -c config.yaml -m model.pth
+```
+
+For additional commands and options:
+
+```bash
+bash scripts/attack/pot_attack.sh --help
+```
+

--- a/scripts/attack/pot_attack.sh
+++ b/scripts/attack/pot_attack.sh
@@ -2,8 +2,10 @@
 # PoT Attack CLI Wrapper Script
 # Provides easy command-line access to attack evaluation tools
 
-# Set Python path
-export PYTHONPATH="${PYTHONPATH}:$(dirname "$0")"
+# Set Python path to repository root
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+export PYTHONPATH="${PYTHONPATH}:${REPO_ROOT}"
 
 # Default Python interpreter
 PYTHON=${PYTHON:-python3}
@@ -25,11 +27,11 @@ check_dependencies() {
         print_color "Error: Python not found. Please install Python 3.8+" "$RED"
         exit 1
     fi
-    
+
     if ! $PYTHON -c "import torch" 2>/dev/null; then
         print_color "Warning: PyTorch not installed. Some features may not work." "$YELLOW"
     fi
-    
+
     if ! $PYTHON -c "import click" 2>/dev/null; then
         print_color "Error: Click not installed. Run: pip install click" "$RED"
         exit 1
@@ -41,7 +43,7 @@ show_help() {
     cat << EOF
 PoT Attack Evaluation CLI
 
-Usage: pot-attack [OPTIONS] COMMAND [ARGS]...
+Usage: pot_attack.sh [OPTIONS] COMMAND [ARGS]...
 
 Commands:
   run-attacks      Run attack suite against model
@@ -50,11 +52,11 @@ Commands:
   benchmark       Run standardized benchmark
   verify          Verify model with PoT
   dashboard       Launch interactive dashboard
-  
+
 Quick Examples:
-  pot-attack run-attacks -m model.pth -s standard
-  pot-attack benchmark -c config.yaml -m model.pth
-  pot-attack dashboard -r results/
+  ./pot_attack.sh run-attacks -m model.pth -s standard
+  ./pot_attack.sh benchmark -c config.yaml -m model.pth
+  ./pot_attack.sh dashboard -r results/
 
 Options:
   --help          Show this help message
@@ -68,7 +70,7 @@ Environment Variables:
   POT_RESULTS_DIR       Results directory
 
 For detailed help on any command:
-  pot-attack COMMAND --help
+  ./pot_attack.sh COMMAND --help
 
 EOF
 }
@@ -91,8 +93,9 @@ case "$1" in
     *)
         # Check dependencies before running
         check_dependencies
-        
+
         # Run the Python CLI
         $PYTHON -m pot.cli.attack_cli "$@"
         ;;
 esac
+


### PR DESCRIPTION
## Summary
- Rename `pot-attack` shell wrapper to `scripts/attack/pot_attack.sh`
- Adjust script to set PYTHONPATH relative to repo and update help text
- Add `scripts/attack/README.md` with usage examples

## Testing
- `bash -n scripts/attack/pot_attack.sh`
- `bash scripts/attack/pot_attack.sh --help | head -n 20`
- `PYTHONPATH=. pytest tests/test_api_verification.py::test_cli_help -q` *(fails: ModuleNotFoundError: No module named 'pot.core.logging')*

------
https://chatgpt.com/codex/tasks/task_e_68a7c112e514832dac28ac358a278c57